### PR TITLE
Add streaming file request helpers to chrisAPI

### DIFF
--- a/js/chrisAPI/src/request.js
+++ b/js/chrisAPI/src/request.js
@@ -49,11 +49,10 @@ export default class Request {
    *
    * @param {string} url - url of the resource
    * @param {?Object} params - search parameters
-   * @param {?Object} extraConfig - optional axios config overrides (e.g., headers)
    *
    * @return {Promise<AxiosResponse>} - JS Promise, resolves to an ``axios response`` object
    */
-  getStream(url, params = null, extraConfig = null) {
+  getStream(url, params = null) {
     const config = this._getConfig(url, 'get');
 
     if (params) {
@@ -61,10 +60,6 @@ export default class Request {
     }
 
     config.responseType = typeof window === 'undefined' ? 'stream' : 'blob';
-
-    if (extraConfig) {
-      Object.assign(config, extraConfig);
-    }
 
     return Request._callAxios(config);
   }

--- a/js/chrisAPI/src/request.js
+++ b/js/chrisAPI/src/request.js
@@ -45,6 +45,31 @@ export default class Request {
   }
 
   /**
+   * Perform a GET request that returns a stream (Node) or blob (browser).
+   *
+   * @param {string} url - url of the resource
+   * @param {?Object} params - search parameters
+   * @param {?Object} extraConfig - optional axios config overrides (e.g., headers)
+   *
+   * @return {Promise<AxiosResponse>} - JS Promise, resolves to an ``axios response`` object
+   */
+  getStream(url, params = null, extraConfig = null) {
+    const config = this._getConfig(url, 'get');
+
+    if (params) {
+      config.params = params;
+    }
+
+    config.responseType = typeof window === 'undefined' ? 'stream' : 'blob';
+
+    if (extraConfig) {
+      Object.assign(config, extraConfig);
+    }
+
+    return Request._callAxios(config);
+  }
+
+  /**
    * Perform a POST request.
    *
    * @param {string} url - url of the resource

--- a/js/chrisAPI/src/userfile.js
+++ b/js/chrisAPI/src/userfile.js
@@ -45,6 +45,24 @@ export class UserFile extends ItemResource {
   }
 
   /**
+   * Fetch the file as a stream (Node) or blob (browser) from the REST API.
+   *
+   * @param {number} [timeout=30000] - request timeout
+   *
+   * @return {Promise<AxiosResponse>} - JS Promise, resolves to the axios response with streaming/blob data
+   */
+  getFileStream(timeout = 30000) {
+    if (this.isEmpty) {
+      throw new RequestException('Item object has not been set!');
+    }
+    const req = new Request(this.auth, 'application/octet-stream', timeout);
+    const item = this.collection.items[0];
+    const blobUrl = Collection.getLinkRelationUrls(item, 'file_resource')[0];
+
+    return req.getStream(blobUrl);
+  }
+
+  /**
    * Fetch the parent folder of this file from the REST API.
    *
    * @param {number} [timeout=30000] - request timeout

--- a/js/chrisAPI/src/userfile.test.js
+++ b/js/chrisAPI/src/userfile.test.js
@@ -75,6 +75,19 @@ describe('User file resources', () => {
         .then(done, done);
     });
 
+    it('can fetch the associated file as a streaming response', (done) => {
+      const result = userFile.getFileStream();
+      result
+        .then((response) => {
+          expect(response.data).to.be.an.instanceof(Blob);
+          return response.data.text();
+        })
+        .then((text) => {
+          expect(text).to.equal('"This is an uploaded test file"');
+        })
+        .then(done, done);
+    });
+
     it('can become public through the REST API', (done) => {
       const result = userFile.makePublic();
       result


### PR DESCRIPTION
## Summary

- add `Request.getStream()` with Node stream / browser blob response handling
- add `UserFile.getFileStream()` for file resource retrieval
- add browser-side coverage for streamed user-file retrieval

This cleanly reapplies the functional change from the unmerged `streaming` branch without its stale generated/lockfile churn. The API is needed by `cumin`/`chell` to support `cat <filename>` for binary and large files.

## Verification

- `yarn prettier --check src/request.js src/userfile.js src/userfile.test.js`
- `yarn build`
- `CHROME_BIN=/usr/bin/chromium yarn test` starts Karma and compiles successfully, but cannot pass in this checkout because its integration tests require a ChRIS backend at `http://localhost:8000`, which is not running here.

## Build Artifacts

Generated `dist` output is intentionally not included: rebuilding from current `master` rewrites unrelated committed bundles/declaration formatting. The source change is kept focused for review and artifacts can be regenerated as part of release packaging.